### PR TITLE
Include pre-release packages in search results

### DIFF
--- a/Data/PackagesSearchResults.cs
+++ b/Data/PackagesSearchResults.cs
@@ -62,7 +62,7 @@ namespace FuGetGallery
                 };
                 try {
                     // System.Console.WriteLine($"DOWNLOADING {package.DownloadUrl}");
-                    var queryUrl = "https://api-v2v3search-0.nuget.org/query?q=" + Uri.EscapeDataString (q);
+                    var queryUrl = "https://api-v2v3search-0.nuget.org/query?prerelease=true&q=" + Uri.EscapeDataString (q);
                     var data = await httpClient.GetStringAsync (queryUrl).ConfigureAwait (false);
                     results.Read (data);
                 }


### PR DESCRIPTION
Prerelease-only packages will not show up in results, this pr will fix this.
Example: https://www.nuget.org/packages/Sejil/