### PR TITLE
Retrieve all pages of package versions

### DIFF
--- a/Data/PackageVersions.cs
+++ b/Data/PackageVersions.cs
@@ -73,10 +73,12 @@ namespace FuGetGallery
                             package.Read (lastPageItems);
                         }
                         else {
-                            var pageUrl = lastPage["@id"].ToString ();
-                            var pageRootJson = await httpClient.GetStringAsync (pageUrl).ConfigureAwait (false);
-                            var pageRoot = JObject.Parse (pageRootJson);
-                            package.Read ((JArray)pageRoot["items"]);
+                            foreach (var page in pages) {
+                                var pageUrl = page["@id"].ToString();
+                                var pageRootJson = await httpClient.GetStringAsync(pageUrl).ConfigureAwait(false);
+                                var pageRoot = JObject.Parse(pageRootJson);
+                                package.Read((JArray)pageRoot["items"]);
+                            }
                         }
                     }
                 }

--- a/Pages/packages/details.cshtml
+++ b/Pages/packages/details.cshtml
@@ -160,7 +160,7 @@
             <span class="caret"></span>
             <span class="sr-only">Toggle Dropdown</span>
         </button>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu long-dropdown-menu">
         @foreach (var v in versions.Versions.OrderByDescending (x => x))
         {
             <li><a href="@GetUrl(oversion:v.VersionString)">@v</a></li>
@@ -178,7 +178,7 @@
             <span class="caret"></span>
             <span class="sr-only">Toggle Dropdown</span>
         </button>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu long-dropdown-menu">
         @foreach (var v in versions.Versions.Where (x => x.CompareTo (versionSpec) < 0).OrderByDescending (x => x))
         {
             <li><a href="@GetUrl(oversion:package.Version, odir:"lib", oassemblyName:"diff", onamespace:v, otypeName:"")">@v</a></li>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -120,3 +120,8 @@ li.diff-Remove {
     text-decoration: line-through;
     text-decoration-color: #000;
 }
+
+.long-dropdown-menu {
+    max-height: 250px;
+    overflow-x: hidden;
+}


### PR DESCRIPTION
This change downloads all package versions across returned pages. It also adds a CSS class to add to potentially long dropdowns to keep them a reasonable size. I'm not sure what height constant you'd prefer here but 250px felt good to me.

Should fix #26.

Thanks for the site! I've definitely enjoyed the API diffing feature and the ease with regards to finding license information. 👍 