### PR TITLE
Render <see langword="..." /> XML doc comments

### DIFF
--- a/Data/TypeDocumentation.cs
+++ b/Data/TypeDocumentation.cs
@@ -188,6 +188,14 @@ namespace FuGetGallery
                         if (cref != null && cref.Value.Length > 2) {
                             WriteMemberLinkHtml (cref.Value, w);
                         }
+                        else {
+                            var langword = x.Attribute ("langword");
+                            if (langword != null && !string.IsNullOrWhiteSpace (langword.Value)) {
+                                w.Write ("<span class=\"inline-code c-kw\">");
+                                WriteEncodedHtml (langword.Value, w);
+                                w.Write ("</span>");
+                            }
+                        }
                     }
                     break;
                 default:


### PR DESCRIPTION
This should fix #42.

Adds some logic for handling `@langword` attributes in `<see>` XML documentation comment elements. The value of `@langword` gets rendered as an inline code keyword.