### PR TITLE
Render <typeparamref> XML doc comments

### DIFF
--- a/Data/TypeDocumentation.cs
+++ b/Data/TypeDocumentation.cs
@@ -190,6 +190,11 @@ namespace FuGetGallery
                         }
                     }
                     break;
+                case "typeparamref":
+                    w.Write ("<span class=\"inline-code c-tr\">");
+                    WriteEncodedHtml (x.Attribute ("name")?.Value ?? "", w);
+                    w.Write ("</span>");
+                    break;
                 default:
                     //WriteEncodedHtml ($"<b>{x.Name.LocalName}</b>", w);
                     break;


### PR DESCRIPTION
Resolves #44.

Renders the `@name` of a `<typeparamref>` XML documentation comment element as an inline code type reference.