### PR TITLE
Improve display of search results in Safari

### DIFF
--- a/Pages/packages/index.cshtml
+++ b/Pages/packages/index.cshtml
@@ -26,7 +26,7 @@
             </div>
             <div class="media-body">
                 <h4><a href="/packages/@Uri.EscapeDataString(@r.PackageId)">@r.PackageId</a><small> by @r.Authors</small></h4>
-                <p style="max-height:3em;overflow:scroll">@r.Description</p>
+                <p style="max-height:5em;overflow:auto">@r.Description</p>
             </div>
         </li>
     }


### PR DESCRIPTION
With a max-height of 3em, Safari always displays scroll bars. By increasing the max-height to 5em and changing overflow:scroll to overflow:auto, the scroll bars disappear making the page much more pleasant to look at.

*Left*: `max-height:3em;overflow:scroll`
*Right*: `max-height:5em;overflow:auto`

<img width="1440" alt="screen shot 2019-01-31 at 10 09 35" src="https://user-images.githubusercontent.com/51363/52044027-62ab3480-2541-11e9-90d7-49c5bd9c44d5.png">
