### PR TITLE
Allow for configuration of multiple package sources

### DIFF
--- a/Data/NugetPackageSource.cs
+++ b/Data/NugetPackageSource.cs
@@ -1,0 +1,24 @@
+namespace FuGetGallery
+{
+    public class NugetPackageSource
+    {
+        public NugetPackageSource (string domainUrl, string displayName, string displayUrl, string packageDetailsUrlFormat, string queryUrlFormat, string versionUrlFormat, string downloadUrlFormat)
+        {
+            DomainUrl = domainUrl;
+            DisplayName = displayName;
+            DisplayUrl = displayUrl;
+            PackageDetailsUrlFormat = packageDetailsUrlFormat;
+            QueryUrlFormat = queryUrlFormat;
+            VersionUrlFormat = versionUrlFormat;
+            DownloadUrlFormat = downloadUrlFormat;
+        }
+
+        public string DomainUrl { get; }
+        public string DisplayName { get; }
+        public string DisplayUrl { get; }
+        public string PackageDetailsUrlFormat { get; }
+        public string QueryUrlFormat { get; }
+        public string VersionUrlFormat { get; }
+        public string DownloadUrlFormat { get; }
+    }
+}

--- a/Data/NugetPackageSources.cs
+++ b/Data/NugetPackageSources.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+
+namespace FuGetGallery
+{
+    public static class NugetPackageSources
+    {
+        private static IConfiguration _configuration;
+
+        private static readonly Lazy<IReadOnlyList<NugetPackageSource>> _packageSources
+            = new Lazy<IReadOnlyList<NugetPackageSource>> (GetPackageSources);
+
+        public static void Configure (IConfiguration configuration)
+            => _configuration = configuration;
+
+        public static IReadOnlyList<NugetPackageSource> PackageSources => _packageSources.Value;
+
+        private static List<NugetPackageSource> GetPackageSources ()
+        {
+            var sources = new List<NugetPackageSource> ();
+
+            var sections = _configuration.GetSection ("NugetPackageSources").GetChildren ();
+
+            foreach (var urlConfigSection in sections) {
+                var domainUrl = urlConfigSection["DomainUrl"];
+                var displayName = urlConfigSection["DisplayName"];
+                var displayUrl = urlConfigSection["DisplayUrl"];
+                var packageDetailUrlFormat = urlConfigSection["PackageDetailsUrlFormat"];
+                var queryUrlFormat = urlConfigSection["QueryUrlFormat"];
+                var versionUrlFormat = urlConfigSection["VersionsUrlFormat"];
+                var downloadUrlFormat = urlConfigSection["DownloadUrlFormat"];
+
+                sources.Add(new NugetPackageSource(domainUrl, displayName, displayUrl,
+                    packageDetailUrlFormat, queryUrlFormat, versionUrlFormat, downloadUrlFormat));
+            }
+
+            if (sources.Any ())
+                return sources;
+
+            // Default configuration if there is no configuration added in appsettings.
+            return new List<NugetPackageSource> {
+                new NugetPackageSource(
+                    "https://www.nuget.org",
+                    "Nuget Gallery",
+                    "nuget.org",
+                    "https://www.nuget.org/packages/{0}/{1}",
+                    "https://api-v2v3search-0.nuget.org/query?prerelease=true&q={0}",
+                    "https://api.nuget.org/v3/registration3/{0}/index.json",
+                    "https://www.nuget.org/api/v2/package/{0}/{1}")
+            };
+        }
+    }
+}

--- a/Pages/index.cshtml
+++ b/Pages/index.cshtml
@@ -1,6 +1,8 @@
 ﻿@page
 @{
     ViewData["Title"] = "Home page";
+
+    var sources = NugetPackageSources.PackageSources;
 }
 
 <h1 style="margin-top:1em;margin-bottom:0.5em;">fuget.org <small>pro nuget package browsing</small></h1>
@@ -8,7 +10,29 @@
 <p>This site is a nuget package browser combined with an API browser.
 
 The package browser uses the
-<a href="https://nuget.org">nuget.org</a> API to display all the packages in their index.
+@if(sources.Count == 1)
+{ 
+    @:<a href="@sources[0].DomainUrl">@sources[0].DisplayName</a> API to display all the packages in their index.
+}
+else if(sources.Count == 2)
+{
+    @:<a href="@sources[0].DomainUrl">@sources[0].DisplayName</a> and <a href="@sources[1].DomainUrl">@sources[1].DisplayName</a> APIs to display all the packages in their index.
+}
+else
+{
+    for (int i = 0; i < sources.Count; i++)
+    {
+        if (i == sources.Count - 1)
+        {
+            @:and <a href="@sources[i].DomainUrl">@sources[i].DisplayName</a> 
+        }
+        else
+        {
+            @:<a href="@sources[i].DomainUrl">@sources[i].DisplayName</a>, 
+        }
+    }
+    @:APIs to display all the packages in their index.
+}
 
 The API browser combines the XML documentation and the metadata of the package's assemblies to
     help you explore and learn. Try the API search box to quickly find code, and use the

--- a/Pages/packages/details.cshtml
+++ b/Pages/packages/details.cshtml
@@ -211,8 +211,8 @@
     <a href="@package.DownloadUrl" type="button" class="btn btn-default" style="color:#777">
         <span class="glyphicon glyphicon-download" aria-hidden="true"></span>&nbsp;@nupkgName
     </a>
-    <a href="https://www.nuget.org/packages/@Uri.EscapeDataString(package.Id)/@Uri.EscapeDataString(package.Version.VersionString)" type="button" class="btn btn-default" style="color: #777">
-        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>&nbsp;nuget.org
+    <a href="@string.Format(package.PackageDetailsUrlFormat, Uri.EscapeDataString(package.Id), Uri.EscapeDataString(package.Version.VersionString))" type="button" class="btn btn-default" style="color: #777">
+        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>&nbsp;@package.DisplayUrl
     </a>
     @if (!string.IsNullOrEmpty(package.ProjectUrl)) {
         <a href="@package.ProjectUrl" type="button" class="btn btn-default" style="color:#777">

--- a/Startup.cs
+++ b/Startup.cs
@@ -18,6 +18,7 @@ namespace FuGetGallery
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
+            NugetPackageSources.Configure (Configuration);
         }
 
         // This method gets called by the runtime. Use this method to add services to the container.

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,8 +1,18 @@
 ﻿{
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
-      "Default": "Warning"
+    "NugetPackageSources": [
+    {
+        "DomainUrl": "https://www.nuget.org",
+        "DisplayName": "Nuget Gallery",
+        "DisplayUrl": "nuget.org",
+        "PackageDetailsUrlFormat": "https://www.nuget.org/packages/{0}/{1}",
+        "QueryUrlFormat": "https://api-v2v3search-0.nuget.org/query?prerelease=true&q={0}",
+        "VersionsUrlFormat": "https://api.nuget.org/v3/registration3/{0}/index.json",
+        "DownloadUrlFormat": "https://www.nuget.org/api/v2/package/{0}/{1}"
+    }],
+    "Logging": {
+        "IncludeScopes": false,
+        "LogLevel": {
+            "Default": "Warning"
+        }
     }
-  }
 }


### PR DESCRIPTION
This adds the ability to configure multiple package sources.  This should solve most of what #13 (and the duplicate #50 ) is asking for.  This does not currently allow for authenticated sources, but it should be a simple addition of more configuration values and adding them to headers.

Adding a new package source is as simple as adding a new entry in the appsettings.json, under NugetPackageSources.  If the NugetPackageSources section is missing completely, it will default to the current nuget.org source.

In order to get this to work with our internal version of Nuget Gallery, I had to add some specific endpoints, because it does not support v3, but anything that does should be able to simply swap out urls.