### PR TITLE
Using NuGet.Versioning.VersionComparer to compare PackageVersions

### DIFF
--- a/FuGetGallery.csproj
+++ b/FuGetGallery.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="System.Security.Permissions" Version="4.5.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="4.5.0" />
     <PackageReference Include="ListDiff" Version="1.0.7" />
+    <PackageReference Include="NuGet.Versioning" Version="5.2.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />


### PR DESCRIPTION
Current code doesn't correctly compare "release" versions with "pre-relase" versions as reported here https://github.com/praeclarum/fuget/issues/2.
This change fixes that issue by using NuGet.Versioning to perform versions comparison. 
