### PR TITLE
Update to use NuGet.org's new search service

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -5,7 +5,7 @@
         "DisplayName": "Nuget Gallery",
         "DisplayUrl": "nuget.org",
         "PackageDetailsUrlFormat": "https://www.nuget.org/packages/{0}/{1}",
-        "QueryUrlFormat": "https://api-v2v3search-0.nuget.org/query?prerelease=true&semVerLevel=2.0.0&q={0}",
+        "QueryUrlFormat": "https://azuresearch-usnc.nuget.org/query?prerelease=true&semVerLevel=2.0.0&q={0}",
         "VersionsUrlFormat": "https://api.nuget.org/v3/registration3/{0}/index.json",
         "DownloadUrlFormat": "https://www.nuget.org/api/v2/package/{0}/{1}"
     }],


### PR DESCRIPTION
See: https://devblogs.microsoft.com/nuget/new-and-improved-nuget-search/
For example: https://azuresearch-usnc.nuget.org/query?prerelease=true&semVerLevel=2.0.0&q=Microsoft.Extensions.Logging

We will be deleting the old search service soon and the URL will no longer exist.