### PR TITLE
Make Types scroll bars in package details optional

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -53,7 +53,7 @@ footer { margin-top: 10em; }
 }
 
 .long-item-list {
-    overflow:scroll;
+    overflow:auto;
     list-style-type:none;
     padding:0;
     white-space:nowrap;


### PR DESCRIPTION
The scroll bars in the Types section of the Package details page are not needed most of the time, so I made the scroll bars optional for `.long-item-list`, just like they are for `ul.pkglist`.

Also, I can see that there scroll bars on the search results / package list page are always visible on fuget.org, despite this change: https://github.com/praeclarum/FuGetGallery/blob/d6deda7afe191d6dfcaa7dd84a988b403e4f5f18/Pages/packages/index.cshtml#L29

And thanks for creating this project ❤