### PR TITLE
Add a tooltip for the assembly version on cover

### DIFF
--- a/Pages/packages/details.cshtml
+++ b/Pages/packages/details.cshtml
@@ -337,7 +337,8 @@ else {
         var cls = (active ? "active " : "") + "public-api";
         <li>
             <a class="@cls"
-               href="/packages/@Uri.EscapeDataString(package.Id)/@Uri.EscapeDataString(package.Version.VersionString)/lib/@Uri.EscapeDataString(framework.Moniker)/@Uri.EscapeDataString(a.FileName)">
+               href="/packages/@Uri.EscapeDataString(package.Id)/@Uri.EscapeDataString(package.Version.VersionString)/lib/@Uri.EscapeDataString(framework.Moniker)/@Uri.EscapeDataString(a.FileName)"
+               title="@a.Definition.Name.Version.ToString()">
                 <span class="glyphicon glyphicon-@GetIcon(a)" aria-hidden="true"></span>&nbsp;@a.FileName</a>
         </li>
     }


### PR DESCRIPTION
Looks like this:

<img width="287" alt="Screenshot 2019-10-03 at 13 14 05" src="https://user-images.githubusercontent.com/109974/66118722-c8275780-e5df-11e9-8dd9-420333bb7b68.png">
