### PR TITLE
Use NuGet.Versioning.SemanticVersion to correctly compare package versions

### DIFF
--- a/Data/PackageVersions.cs
+++ b/Data/PackageVersions.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Net.Http;
-using Newtonsoft.Json.Linq;
 using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
 
 namespace FuGetGallery
 {
@@ -120,11 +120,8 @@ namespace FuGetGallery
     {
         string versionString = "";
 
-        public int Major { get; private set; }
-        public int Minor { get; private set; }
-        public int Patch { get; private set; }
-        public int Build { get; private set; }
-        public string Rest { get; private set; } = "";
+        public SemanticVersion SemanticVersion { get; private set; }
+
         public DateTime? PublishTime { get; set; }
 
         public bool IsPublished => PublishTime.HasValue && PublishTime.Value.Year > 1970;
@@ -135,38 +132,13 @@ namespace FuGetGallery
                 if (versionString == value || string.IsNullOrEmpty (value))
                     return;
                 versionString = value;
-                var di = value.IndexOf ('-');
-                var vpart = di > 0 ? value.Substring (0, di) : value;
-                var rest = di > 0 ? value.Substring (di) : "";
-                var parts = vpart.Split ('.');
-                var maj = 0;
-                var min = 0;
-                var patch = 0;
-                var build = 0;
-                if (parts.Length > 0) int.TryParse(parts[0], out maj);
-                if (parts.Length > 1) int.TryParse(parts[1], out min);
-                if (parts.Length > 2) int.TryParse(parts[2], out patch);
-                if (parts.Length > 3) int.TryParse (parts[3], out build);
-                Major = maj;
-                Minor = min;
-                Patch = patch;
-                Build = build;
-                Rest = rest;
+
+                SemanticVersion.TryParse (value, out var semanticVersion);
+                SemanticVersion = semanticVersion;
             }
         }
 
-        public int CompareTo(PackageVersion other)
-        {
-            var c = Major.CompareTo(other.Major);
-            if (c != 0) return c;
-            c = Minor.CompareTo(other.Minor);
-            if (c != 0) return c;
-            c = Patch.CompareTo(other.Patch);
-            if (c != 0) return c;
-            c = Build.CompareTo (other.Build);
-            if (c != 0) return c;
-            return string.Compare(Rest, other.Rest, StringComparison.Ordinal);
-        }
+        public int CompareTo(PackageVersion other) => Comparer<SemanticVersion>.Default.Compare (SemanticVersion, other.SemanticVersion);
 
         public override bool Equals(object obj)
         {

--- a/FuGetGallery.csproj
+++ b/FuGetGallery.csproj
@@ -11,6 +11,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="NGraphics" Version="0.6.0-beta1" />
+    <PackageReference Include="NuGet.Versioning" Version="5.3.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.6.258-beta" />
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />


### PR DESCRIPTION
Fixes https://github.com/praeclarum/FuGetGallery/issues/63.

With this change, prerelease versions of packages are sorted correctly:

![](https://user-images.githubusercontent.com/287848/66697927-0d334400-ecda-11e9-9595-80db474b36f9.png)
