### PR TITLE
Allow 'totalDownloads' to be missing from search results JSON

### DIFF
--- a/Data/PackagesSearchResults.cs
+++ b/Data/PackagesSearchResults.cs
@@ -47,7 +47,7 @@ namespace FuGetGallery
                         Version = (string)x["version"],
                         Description = (string)x["description"],
                         IconUrl = (string)x["iconUrl"],
-                        TotalDownloads = (int)x["totalDownloads"],
+                        TotalDownloads = ((int?)x["totalDownloads"]) ?? 0,
                         Authors = string.Join (", ", x["authors"]),
                     });
                 }
@@ -57,7 +57,7 @@ namespace FuGetGallery
                         existingResult.Version = newVersion;
                         existingResult.Description = (string)x["description"];
                         existingResult.IconUrl = (string)x["iconUrl"];
-                        existingResult.TotalDownloads = (int)x["totalDownloads"];
+                        existingResult.TotalDownloads = ((int?)x["totalDownloads"]) ?? 0;
                         existingResult.Authors = string.Join (", ", x["authors"]);
                     }
                 }


### PR DESCRIPTION
Azure Artifacts supports the v3 NuGet Search API, but doesn't return a `totalDownloads` property for each package. (I can't provide an example URL, sorry.) We now just set this property (which isn't currently used) to zero if it's missing in the JSON.

Without this change, searching displays the following error in the UI:

> System.ArgumentNullException: Value cannot be null. Parameter name: value at Newtonsoft.Json.Linq.JToken.EnsureValue(JToken value) at Newtonsoft.Json.Linq.JToken.op_Explicit(JToken value) at FuGetGallery.PackagesSearchResults.Read(String json) in C:\Code\FuGetGallery\Data\PackagesSearchResults.cs:line 45 at FuGetGallery.PackagesSearchResults.ResultsCache.GetValueAsync(String q, HttpClient httpClient, CancellationToken token) in C:\Code\FuGetGallery\Data\PackagesSearchResults.cs:line 87