### PR TITLE
Fall back to manual version parsing if SemanticVersion fails

### DIFF
--- a/Data/PackageVersions.cs
+++ b/Data/PackageVersions.cs
@@ -119,6 +119,11 @@ namespace FuGetGallery
     public class PackageVersion : IComparable<PackageVersion>
     {
         string versionString = "";
+        int major;
+        int minor;
+        int patch;
+        int build;
+        string rest = "";
 
         public SemanticVersion SemanticVersion { get; private set; }
 
@@ -133,12 +138,54 @@ namespace FuGetGallery
                     return;
                 versionString = value;
 
-                SemanticVersion.TryParse (value, out var semanticVersion);
-                SemanticVersion = semanticVersion;
+                if (SemanticVersion.TryParse (value, out var semanticVersion)) {
+                    SemanticVersion = semanticVersion;
+                } else {
+                    // SemanticVersion only supports 3-part version numbers (major.minor.patch); fall back to parsing
+                    // the version string manually if it fails.
+                    var di = value.IndexOf ('-');
+                    var vpart = di > 0 ? value.Substring (0, di) : value;
+                    rest = di > 0 ? value.Substring (di) : "";
+                    var parts = vpart.Split ('.');
+                    major = 0;
+                    minor = 0;
+                    patch = 0;
+                    build = 0;
+                    if (parts.Length > 0)
+                        int.TryParse (parts[0], out major);
+                    if (parts.Length > 1)
+                        int.TryParse (parts[1], out minor);
+                    if (parts.Length > 2)
+                        int.TryParse (parts[2], out patch);
+                    if (parts.Length > 3)
+                        int.TryParse (parts[3], out build);
+                }
             }
         }
 
-        public int CompareTo(PackageVersion other) => Comparer<SemanticVersion>.Default.Compare (SemanticVersion, other.SemanticVersion);
+        public int CompareTo(PackageVersion other)
+        {
+            if (other is null)
+                return 1;
+
+            if (SemanticVersion is null && other.SemanticVersion is null) {
+                var c = major.CompareTo (other.major);
+                if (c != 0)
+                    return c;
+                c = minor.CompareTo (other.minor);
+                if (c != 0)
+                    return c;
+                c = patch.CompareTo (other.patch);
+                if (c != 0)
+                    return c;
+                c = build.CompareTo (other.build);
+                if (c != 0)
+                    return c;
+                return string.Compare (rest, other.rest, StringComparison.Ordinal);
+            }
+            
+            return Comparer<SemanticVersion>.Default.Compare (SemanticVersion, other.SemanticVersion);
+        }
 
         public override bool Equals(object obj)
         {


### PR DESCRIPTION
`SemanticVersion` only supports three part (major.minor.patch) version numbers (plus suffixes); any version number not fitting that format will have a `SemanticVersion` of `null` and thus be considered equal.

This commit restores the previous version parsing logic (before #83) as a fallback for when `SemanticVersion` fails to parse a version number.

I ran into this when displaying packages from a feed that used Windows-style four-part version numbers instead of three-part version numbers. They were all considered to have the same `null` SemanticVersion and appeared unordered in the UI.

As per 1c63a21d8f55df79e2022c885dc21b2a394afded there must previously have been packages with four-part version numbers (since the code was extended to handle them); this PR reinstates support for packages versioned that way (while still preferring to compare packages by `SemanticVersion`).

This also fixes a minor bug where `PackageVersion.CompareTo` didn't handle a `null` argument correctly. (All non-null objects should be "greater than" `null`.)