### PR TITLE
Target .NET Core 3.1

### DIFF
--- a/FuGetGallery.csproj
+++ b/FuGetGallery.csproj
@@ -1,16 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ICSharpCode.Decompiler" Version="3.2.0.3856" />
     <PackageReference Include="Mono.Cecil" Version="0.10.4" />
-    <PackageReference Include="Microsoft.AspNetCore.All">
-      <PrivateAssets Condition="'%(PackageReference.Version)' == ''">all</PrivateAssets>
-      <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.6" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NGraphics" Version="0.6.0-beta1" />
     <PackageReference Include="NuGet.Versioning" Version="5.3.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.6.258-beta" />
@@ -23,7 +20,7 @@
     <PackageReference Include="ListDiff" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Licenses\Apache2.txt" />

--- a/Program.cs
+++ b/Program.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace FuGetGallery
 {
@@ -14,12 +7,14 @@ namespace FuGetGallery
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            BuildWebHost (args).Run ();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
+        public static IHost BuildWebHost(string[] args) =>
+            Host.CreateDefaultBuilder (args)
+                .ConfigureWebHostDefaults (webBuilder => {
+                    webBuilder.UseStartup<Startup> ();
+                })
+                .Build ();
     }
 }

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,15 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace FuGetGallery
 {
@@ -28,7 +24,7 @@ namespace FuGetGallery
         {
             new Database ().MigrateAsync ().Wait ();
             services.AddScoped<Database, Database> ();
-            services.AddMvc().AddRazorPagesOptions(options =>
+            services.AddRazorPages(options =>
             {
                 options.Conventions.AddPageRoute("/packages/details", "packages/{id}");
                 options.Conventions.AddPageRoute("/packages/badges", "packages/{id}/badges");
@@ -49,7 +45,7 @@ namespace FuGetGallery
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseResponseCompression();
 
@@ -61,7 +57,11 @@ namespace FuGetGallery
             }
 
             app.UseStaticFiles();
-            app.UseMvc();
+            app.UseRouting();
+            app.UseEndpoints (configure => {
+                configure.MapControllers ();
+                configure.MapRazorPages ();
+            });
         }
     }
 }


### PR DESCRIPTION
I'm not sure what your plans for targeting newer versions of .NET Core are, and although I could have opened an issue to discuss first, I was going to do this work anyway, so I thought I'd simply share the code as a PR to start the discussion.

Targetting .NET Core 3.1 will allow newer C# language versions to be used more easily and will use the latest runtime and performance improvements in .NET Core 3.1. It's also an LTS release.

Ported following the instructions at https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30.

