### PR TITLE
Special-case the MySql.Data GPL license

### DIFF
--- a/Data/License.cs
+++ b/Data/License.cs
@@ -96,6 +96,7 @@ namespace FuGetGallery
                     "https://www.gnu.org/licenses/gpl-2.0.html",
                     "http://opensource.org/licenses/GPL-2.0",
                     "https://opensource.org/licenses/GPL-2.0",
+                    "https://downloads.mysql.com/docs/licenses/connector-net-8.0-gpl-en.pdf",
                 },
                 TemplateName = "GPL2",
             });


### PR DESCRIPTION
FuGet incorrectly identifies MySql.Data as using the MIT license: https://www.fuget.org/packages/MySql.Data

This occurs because the license URL is https://downloads.mysql.com/docs/licenses/connector-net-8.0-gpl-en.pdf which doesn't match any known license. When this file is downloaded, its plain text (of the PDF source) arbitrarily matches "MIT License", which occurs in the file.

Rather than adding more sophisticated logic for (for example) only string matching on files <1KB or rejecting matches on multiple licenses, this simply hard-codes MySql.Data's license URL as matching GPL 2 (which is the license claimed by the package).