### PR TITLE
Only return an AggregateException if exceptions were thrown

### DIFF
--- a/Data/PackagesSearchResults.cs
+++ b/Data/PackagesSearchResults.cs
@@ -92,7 +92,7 @@ namespace FuGetGallery
                     }
                 }
 
-                if (!succeededOnce) {
+                if (!succeededOnce && exceptions.Count > 0) {
                     results.Error = exceptions.Count == 1 
                         ? exceptions[0] 
                         : new AggregateException(exceptions);


### PR DESCRIPTION
Currently, if there are no results for the search term, an empty AggregateException will be generated and returned. 

As an example see: https://www.fuget.org/packages?q=ThisSearchTermWillProduceNoResults

I have added an extra check to ensure that an AggregateException is only returned if there are actually some exceptions that were thrown.