### PR TITLE
NullReferenceException when encountering <see langword="xxx" />

### DIFF
--- a/Data/PackageAssemblyXmlDocs.cs
+++ b/Data/PackageAssemblyXmlDocs.cs
@@ -83,7 +83,13 @@ namespace FuGetGallery
                 if (n is XElement el) {
                     if (el.Name == "see") {
                         var cref = el.Attribute (element.Name.Namespace + "cref")?.Value;
-                        return cref.Substring (cref.LastIndexOf ('.') + 1);
+                        if (cref != null) {
+                            return cref.Substring (cref.LastIndexOf ('.') + 1);
+                        }
+                        var langword = el.Attribute (element.Name.Namespace + "langword")?.Value;
+                        if (langword != null) {
+                            return langword;
+                        }
                     }
                     return string.Empty;
                 }


### PR DESCRIPTION
Previously the code to read XmlDoc expected `see` elements to have a `cref` attribute. However, in case of `<see langword="xxx" />`, this resulted in a `NullReferenceException`.

This PR fixes this and returns the correct langword as text element.