### PR TITLE
Display a message when a search has no results

### DIFF
--- a/Pages/packages/index.cshtml
+++ b/Pages/packages/index.cshtml
@@ -15,6 +15,8 @@
 @if (results != null) {
     if (results.Error != null) {
         <p>@results.Error</p>
+    } else if (results.Results.Count == 0) {
+        <p>No packages were found for <b>@q</b></p>
     }
     <ul class="media-list">
     @foreach (var r in results.Results) {


### PR DESCRIPTION
This avoids blank output (e.g., at https://www.fuget.org/packages?q=ABCXYZ) which can make it unclear whether the search worked or not.