### PR TITLE
Support SemVer 2 packages

### DIFF
--- a/Startup.cs
+++ b/Startup.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -40,7 +42,10 @@ namespace FuGetGallery
             });
             services.Configure<GzipCompressionProviderOptions>(options => options.Level = System.IO.Compression.CompressionLevel.Optimal);
             services.AddResponseCompression();
-            services.AddHttpClient();
+            services.AddHttpClient ("")
+                .ConfigurePrimaryHttpMessageHandler (() => new HttpClientHandler {
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/appsettings.json
+++ b/appsettings.json
@@ -6,7 +6,7 @@
         "DisplayUrl": "nuget.org",
         "PackageDetailsUrlFormat": "https://www.nuget.org/packages/{0}/{1}",
         "QueryUrlFormat": "https://azuresearch-usnc.nuget.org/query?prerelease=true&semVerLevel=2.0.0&q={0}",
-        "VersionsUrlFormat": "https://api.nuget.org/v3/registration3/{0}/index.json",
+        "VersionsUrlFormat": "https://api.nuget.org/v3/registration4-gz-semver2/{0}/index.json",
         "DownloadUrlFormat": "https://www.nuget.org/api/v2/package/{0}/{1}"
     }],
     "Logging": {


### PR DESCRIPTION
This fixes #75.

Also upgrade to `registration4` endpoint, which includes more package versions (see #95).