### PR TITLE
Read all pages of a package's results

### DIFF
--- a/Data/PackageVersions.cs
+++ b/Data/PackageVersions.cs
@@ -97,19 +97,16 @@ namespace FuGetGallery
                 // Console.WriteLine(rootJson + "\n\n\n\n");
                 var root = JObject.Parse (rootJson);
                 var pages = (JArray)root["items"];
-                if (pages.Count > 0) {
-                    var lastPage = pages.Last ();
-                    var lastPageItems = lastPage["items"] as JArray;
-                    if (lastPageItems != null) {
-                        package.Read (lastPageItems);
+                foreach (var p in pages) {
+                    var pageItems = p["items"] as JArray;
+                    if (pageItems != null) {
+                        package.Read (pageItems);
                     }
                     else {
-                        foreach (var p in pages.Reverse ()) {
-                            var pageUrl = p["@id"].ToString ();
-                            var pageRootJson = await httpClient.GetStringAsync (pageUrl).ConfigureAwait (false);
-                            var pageRoot = JObject.Parse (pageRootJson);
-                            package.Read ((JArray)pageRoot["items"]);
-                        }
+                        var pageUrl = p["@id"].ToString ();
+                        var pageRootJson = await httpClient.GetStringAsync (pageUrl).ConfigureAwait (false);
+                        var pageRoot = JObject.Parse (pageRootJson);
+                        package.Read ((JArray)pageRoot["items"]);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #95.

When the NuGet API returns package versions as part of the response, the code only read the versions from the last page. It now reads the versions from all pages, whether they're returned inline or referenced via a secondary URL.