### PR TITLE
Add explicit Mono.Cecil dependency

### DIFF
--- a/Data/CecilExtensions.cs
+++ b/Data/CecilExtensions.cs
@@ -356,21 +356,21 @@ namespace FuGetGallery
                     w.Write (" : ");
                     var head = "";
                     foreach (var c in p.Constraints) {
-                        if (c.FullName == "System.Object") {
+                        if (c.ConstraintType.FullName == "System.Object") {
                             w.Write ("class");
                             head = ", ";
                             break;
                         }
-                        else if (c.FullName == "System.ValueType") {
+                        else if (c.ConstraintType.FullName == "System.ValueType") {
                             w.Write ("struct");
                             head = ", ";
                             break;
                         }
                     }
                     foreach (var c in p.Constraints) {
-                        if (c.FullName != "System.ValueType" && c.FullName != "System.Object") {
+                        if (c.ConstraintType.FullName != "System.ValueType" && c.ConstraintType.FullName != "System.Object") {
                             w.Write (head);
-                            WriteReferenceHtml (c, w, framework);
+                            WriteReferenceHtml (c.ConstraintType, w, framework);
                             head = ", ";
                         }
                     }

--- a/FuGetGallery.csproj
+++ b/FuGetGallery.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ICSharpCode.Decompiler" Version="3.1.0.3652" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.2" />
     <PackageReference Include="Microsoft.AspNetCore.All">
       <PrivateAssets Condition="'%(PackageReference.Version)' == ''">all</PrivateAssets>
       <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>


### PR DESCRIPTION
Right now it use 0.10 dependency from ICSharpCode.Decompiler, which fails on some assemblies. E.g. https://www.fuget.org/packages/Oracle.ManagedDataAccess