### PR TITLE
Adds "none" to dependents list if none

### DIFF
--- a/Pages/packages/details.cshtml
+++ b/Pages/packages/details.cshtml
@@ -6,7 +6,6 @@
     var httpClient = HttpClientFactory.CreateClient();
     var package = await PackageData.GetAsync (RouteData.Values["id"], RouteData.Values["version"], httpClient);
     var authors = package.AuthorsOrOwners;
-
     var versions = await PackageVersions.GetAsync (RouteData.Values["id"], httpClient, HttpContext.RequestAborted);
     var versionSpec = package.Version;
 
@@ -280,6 +279,11 @@
         <a class="btn btn-default btn-sm" style="color:#777"
             href="/packages/@Uri.EscapeDataString(package.Id)/dependents">@(dependents.Count - maxDisplayDependents) more...</a>
     }
+    </nav>
+}
+else {
+    <nav style="margin-top:0em;line-height:2.75em;">
+        <h4 style="margin-top:0.5em;color:#777;display:inline-block;margin-right:0.5em;padding:0;">Dependents : <strong>none</strong></h4>
     </nav>
 }
 


### PR DESCRIPTION
This makes it clearer when there are no dependents, rather than just hiding the heading