### PR TITLE
Use registration5 instead of registration4

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -6,7 +6,7 @@
         "DisplayUrl": "nuget.org",
         "PackageDetailsUrlFormat": "https://www.nuget.org/packages/{0}/{1}",
         "QueryUrlFormat": "https://azuresearch-usnc.nuget.org/query?prerelease=true&semVerLevel=2.0.0&q={0}",
-        "VersionsUrlFormat": "https://api.nuget.org/v3/registration4-gz-semver2/{0}/index.json",
+        "VersionsUrlFormat": "https://api.nuget.org/v3/registration5-gz-semver2/{0}/index.json",
         "DownloadUrlFormat": "https://www.nuget.org/api/v2/package/{0}/{1}"
     }],
     "Logging": {


### PR DESCRIPTION
I rebuilt nuget.org registration job to have better performance. As part of this rollout, registration5 (not registration4) is now the latest version. See https://github.com/NuGet/NuGetGallery/issues/7734 for more details.

![image](https://user-images.githubusercontent.com/94054/81240653-d2b62f00-8fbc-11ea-9db6-8d1f6a217867.png)
