### PR TITLE
Default to latest pre-release version if the package has only pre-release versions

### DIFF
--- a/Data/PackageData.cs
+++ b/Data/PackageData.cs
@@ -404,6 +404,12 @@ namespace FuGetGallery
             {
                 //System.Console.WriteLine($"DOWNLOADING {package.DownloadUrl}");
                 var r = await httpClient.GetAsync (package.DownloadUrl, token).ConfigureAwait (false);
+                try {
+                    r.EnsureSuccessStatusCode ();
+                }
+                catch (Exception ex) {
+                    throw new Exception($"Failed to download {package.DownloadUrl}", ex);
+                }
                 var data = new MemoryStream ();
                 using (var s = await r.Content.ReadAsStreamAsync ().ConfigureAwait (false)) {
                     await s.CopyToAsync (data, 16 * 1024, token).ConfigureAwait (false);

--- a/Data/PackageData.cs
+++ b/Data/PackageData.cs
@@ -404,11 +404,8 @@ namespace FuGetGallery
             {
                 //System.Console.WriteLine($"DOWNLOADING {package.DownloadUrl}");
                 var r = await httpClient.GetAsync (package.DownloadUrl, token).ConfigureAwait (false);
-                try {
-                    r.EnsureSuccessStatusCode ();
-                }
-                catch (Exception ex) {
-                    throw new Exception($"Failed to download {package.DownloadUrl}", ex);
+                if (!r.IsSuccessStatusCode) {
+                    throw new Exception($"Failed to download {package.DownloadUrl} due to HTTP response status code {r.StatusCode}.");
                 }
                 var data = new MemoryStream ();
                 using (var s = await r.Content.ReadAsStreamAsync ().ConfigureAwait (false)) {

--- a/Data/PackageVersions.cs
+++ b/Data/PackageVersions.cs
@@ -28,7 +28,7 @@ namespace FuGetGallery
             var version = (inputVersion ?? "").ToString().Trim().ToLowerInvariant();
             var v = Versions.FirstOrDefault (x => x.ShortVersionString == version);
             if (v == null) {
-                v = Versions.LastOrDefault (x => !x.IsPreRelease);
+                v = Versions.LastOrDefault (x => !x.IsPreRelease) ?? Versions.LastOrDefault ();
             }
             if (v == null) {
                 v = new PackageVersion {

--- a/Pages/packages/badges.cshtml
+++ b/Pages/packages/badges.cshtml
@@ -47,5 +47,5 @@
 <h3>Query Parameters</h3>
 <dl>
     <dt>v</dt>
-    <dd>Version to display. Defaults to the latest pre-release.</dd>
+    <dd>Version to display. Defaults to the latest release, or latest pre-release if the package has only pre-release versions.</dd>
 </dl>


### PR DESCRIPTION
For example, this is currently the case for the BaGet.Protocol package.

Before this pull request, an error is displayed when accessing the [BaGet.Protocol](https://www.fuget.org/packages/BaGet.Protocol) page without specifying a version:
```
System.IO.InvalidDataException: End of Central Directory record could not be found.
   at System.IO.Compression.ZipArchive.ReadEndOfCentralDirectory()
   at System.IO.Compression.ZipArchive.Init(Stream stream, ZipArchiveMode mode, Boolean leaveOpen)
   at System.IO.Compression.ZipArchive..ctor(Stream stream, ZipArchiveMode mode, Boolean leaveOpen, Encoding entryNameEncoding)
   at FuGetGallery.PackageData.Read(MemoryStream bytes, HttpClient httpClient) in D:\home\site\repository\Data\PackageData.cs:line 118
   at FuGetGallery.PackageData.PackageDataCache.<>c__DisplayClass2_0.<ReadPackageFromUrl>b__0() in D:\home\site\repository\Data\PackageData.cs:line 412
   at System.Threading.Tasks.Task.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__278_1(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
--- End of stack trace from previous location where exception was thrown ---
   at FuGetGallery.PackageData.PackageDataCache.ReadPackageFromUrl(PackageData package, HttpClient httpClient, CancellationToken token) in D:\home\site\repository\Data\PackageData.cs:line 412
   at FuGetGallery.PackageData.PackageDataCache.GetValueAsync(String arg0, PackageVersion arg1, HttpClient httpClient, CancellationToken token) in D:\home\site\repository\Data\PackageData.cs:line 385
```

After this pull request, the page when no version is specified defaults to the latest pre-release version if the package has only pre-release versions.

Also, the exception if a package can not be downloaded from nuget.org has been improved. `End of Central Directory record could not be found.` looks like a corrupted zip file when the problem is actually that the zip failed to download. The new exception makes it easier to understand what is happening: `System.Exception: Failed to download https://www.nuget.org/api/v2/package/baget.protocol/0 ---> System.Net.Http.HttpRequestException: Response status code does not indicate success: 404 (Not Found).` 