### PR TITLE
Default to a pre-release package if there are no others

### DIFF
--- a/Data/PackageVersions.cs
+++ b/Data/PackageVersions.cs
@@ -28,7 +28,7 @@ namespace FuGetGallery
             var version = (inputVersion ?? "").ToString().Trim().ToLowerInvariant();
             var v = Versions.FirstOrDefault (x => x.ShortVersionString == version);
             if (v == null) {
-                v = Versions.LastOrDefault (x => !x.IsPreRelease);
+                v = Versions.LastOrDefault (x => !x.IsPreRelease) ?? Versions.LastOrDefault ();
             }
             if (v == null) {
                 v = new PackageVersion {


### PR DESCRIPTION
Fixes https://github.com/praeclarum/FuGetGallery/issues/118.

If there are no stable packages, shows the last pre-release package by default.