### PR TITLE
Allow all file extensions

### DIFF
--- a/web.config
+++ b/web.config
@@ -2,7 +2,11 @@
 <configuration>
     <system.webServer>
         <security>
-            <requestFiltering allowDoubleEscaping="true" />
+            <requestFiltering allowDoubleEscaping="true">
+                <fileExtensions>
+                    <clear />
+                </fileExtensions>
+            </requestFiltering>
         </security>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
Allows all file extensions that are disabled by default. From https://docs.microsoft.com/en-us/iis/configuration/system.webserver/security/requestfiltering/fileextensions/.

Fixes https://github.com/praeclarum/FuGetGallery/issues/122.

