### PR TITLE
Fix issue with diffing with pre-release pkg containing uppercase char

### DIFF
--- a/Data/PackageVersions.cs
+++ b/Data/PackageVersions.cs
@@ -25,8 +25,8 @@ namespace FuGetGallery
 
         public PackageVersion GetVersion (object inputVersion)
         {
-            var version = (inputVersion ?? "").ToString().Trim().ToLowerInvariant();
-            var v = Versions.FirstOrDefault (x => x.ShortVersionString == version);
+            var version = (inputVersion ?? "").ToString().Trim();
+            var v = Versions.FirstOrDefault (x => StringComparer.OrdinalIgnoreCase.Equals(x.ShortVersionString, version));
             if (v == null) {
                 v = Versions.LastOrDefault (x => !x.IsPreRelease) ?? Versions.LastOrDefault ();
             }


### PR DESCRIPTION
This fixes an issue with the "diff" feature when one of the package versions is a pre-release package with an uppercase character. Previously this would fall into the first `v == null` case and the diff would end up targeting the latest non-pre-release version.

I fixed this as I was listening to your podcast and was reminded this was the one bug that ... bugged me about fuget. Didn't realize Merge Conflict existed before today, so happy to have discovered that as well.