### PR TITLE
package download optimization POC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ autom4te.cache/
 tarballs/
 test-results/
 Thumbs.db
+*.sqlite3
 
 # Mac bundle stuff
 *.dmg

--- a/Data/PackageAssembly.cs
+++ b/Data/PackageAssembly.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.IO.Compression;
 using System.Threading.Tasks;
 using System.Linq;
 using Mono.Cecil;
@@ -38,17 +37,18 @@ namespace FuGetGallery
 
         public override string ToString () => Definition.Name.Name;
 
-        public PackageAssembly (ZipArchiveEntry entry, PackageTargetFramework framework)
+        public PackageAssembly (Entry entry, PackageTargetFramework framework)
             : base (entry)
         {
             this.framework = framework;
-            var ms = new MemoryStream ((int)ArchiveEntry.Length);
-            using (var es = entry.Open ()) {
-                es.CopyTo (ms);
-                ms.Position = 0;
-            }
+            
             definition = new Lazy<AssemblyDefinition> (() => {
                 try {
+                    var ms = new MemoryStream ((int)ArchiveEntry.Length);
+                    using (var es = entry.Open ()) {
+                        es.CopyTo (ms);
+                        ms.Position = 0;
+                    }
                     return AssemblyDefinition.ReadAssembly (ms, new ReaderParameters {
                         AssemblyResolver = framework.AssemblyResolver,
                     });

--- a/Data/PackageData.cs
+++ b/Data/PackageData.cs
@@ -66,11 +66,20 @@ namespace FuGetGallery
             req.Headers.Add ("Range", "bytes=" + deflateStart + "-" + (deflateStart + CompressedSize - 1));
 
             resp = await client.SendAsync (req);
-            var stream = await resp.Content.ReadAsStreamAsync();
+            Stream stream = await resp.Content.ReadAsStreamAsync ();
+            if (Mode == 8)  // deflate
+            {
+                stream = new DeflateStream (stream, CompressionMode.Decompress, false);
+            }
+            else {
+                if (Mode != 0) { // store
+                    throw new NotSupportedException ("Compression mode " + Mode + " not supported");
+                }
+            }
 
-            var ds = new DeflateStream (stream, CompressionMode.Decompress, false);
-            ds.CopyTo (ms);
+            stream.CopyTo (ms);
             ms.Position = 0;
+            stream.Dispose ();
             return ms;
         }
     }

--- a/Data/PackageFile.cs
+++ b/Data/PackageFile.cs
@@ -1,14 +1,13 @@
-using System.IO.Compression;
 
 namespace FuGetGallery
 {
     public class PackageFile
     {
-        public ZipArchiveEntry ArchiveEntry { get; }
-        public string FileName => ArchiveEntry?.Name;
+        public Entry ArchiveEntry { get; }
+        public string FileName => ArchiveEntry?.FullName;
         public long SizeInBytes => ArchiveEntry != null ? ArchiveEntry.Length : 0;
 
-        public PackageFile (ZipArchiveEntry entry)
+        public PackageFile (Entry entry)
         {
             ArchiveEntry = entry;
         }

--- a/Pages/packages/details.cshtml
+++ b/Pages/packages/details.cshtml
@@ -402,7 +402,9 @@ else
                             <li>
                                 <a class="@cls"
                                    href="/packages/@Uri.EscapeDataString(package.Id)/@Uri.EscapeDataString(package.Version.ShortVersionString)/lib/@Uri.EscapeDataString(framework.Moniker)/@Uri.EscapeDataString(a.FileName)"
-                                   title="@a.Definition.Name.Version.ToString()">
+                                   @*Rendering this title is problematic because it attempts to load the assembly*@
+                                   @*title="@a.Definition.Name.Version.ToString()"*@
+                                   >
                                     <span class="fugeticon fugeticon-@GetIcon(a)" aria-hidden="true"></span>&nbsp;@a.FileName
                                 </a>
                             </li>


### PR DESCRIPTION
This is a proof of concept (very rough) of an optimization to avoid downloading and caching entire packages. It uses [the structure of the zip archive](https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.3.TXT) and [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) to only download "slices" of the zip package instead of downloading the whole thing. 

It seems that in a lot of these large packages the "bloat" is due to large native binaries that fuget doesn't do anything with. No reason to download and cache those, unfortunately with the current approach everything comes along for the ride.

The bulk of the changes are in PackageData.cs, and replace usage of the ZipArchive class with manually requesting sub-ranges of the package to retrieve just the "table of contents". This requires more HTTP roundtrips, but the overall data transferred should be tiny by comparison.

There are a couple other changes to lazily access streams only when needed. Newtonsoft.JSON, for example, carries 9 distinct copies of the dll and xml for the various frameworks it supports. Rather than loading each of those eagerly, I tried to make the access happen on-demand.

It is worth point out that there is currently *zero* caching happening in this implementation, beyond holding on to the table of entries for each package. Each request for a dll or xml is going over the network. Obviously needs to be fixed.

Will this fix the OOM issue being discussed in #108? I'm not sure. After caching is applied to this I think it might still be susceptible to LOH fragmentation, but I suspect it will, at the least, be greatly reduced.

There are various to-dos and known-issues that need to be considered, but I thought this proof of concept would be place to start a discussion. Let me know what you think.