### PR TITLE
Use C# 9 top-level statements

### DIFF
--- a/FuGetGallery.csproj
+++ b/FuGetGallery.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ICSharpCode.Decompiler" Version="3.2.0.3856" />

--- a/Program.cs
+++ b/Program.cs
@@ -1,20 +1,9 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
-namespace FuGetGallery
-{
-    public class Program
-    {
-        public static void Main(string[] args)
-        {
-            BuildWebHost (args).Run ();
-        }
-
-        public static IHost BuildWebHost(string[] args) =>
-            Host.CreateDefaultBuilder (args)
-                .ConfigureWebHostDefaults (webBuilder => {
-                    webBuilder.UseStartup<Startup> ();
-                })
-                .Build ();
-    }
-}
+Host.CreateDefaultBuilder (args)
+    .ConfigureWebHostDefaults (webBuilder => {
+        webBuilder.UseStartup<FuGetGallery.Startup> ();
+    })
+    .Build ()
+    .Run ();


### PR DESCRIPTION
Now that the project is targeting .NET 5, C# 9.0 features can begin to be used.

I thought a nice one to clean up some unnecessary boilerplate is the top-level statements feature.