### PR TITLE
Cache files locally

### DIFF
--- a/Data/PackageTargetFramework.cs
+++ b/Data/PackageTargetFramework.cs
@@ -59,7 +59,7 @@ namespace FuGetGallery
                 return url;
 
             var types =
-                from a in Assemblies.Where(a => !a.FileName.Contains(".resources.", StringComparison.OrdinalIgnoreCase)).Concat (BuildAssemblies)
+                from a in Assemblies.Concat (BuildAssemblies)
                 from m in a.Definition?.Modules ?? Enumerable.Empty<ModuleDefinition> ()
                 select new { a, t = m?.GetType (typeFullName) };
             var at = types.FirstOrDefault (x => x.t != null);

--- a/Data/PackageTargetFramework.cs
+++ b/Data/PackageTargetFramework.cs
@@ -59,7 +59,7 @@ namespace FuGetGallery
                 return url;
 
             var types =
-                from a in Assemblies.Concat (BuildAssemblies)
+                from a in Assemblies.Where(a => !a.FileName.Contains(".resources.", StringComparison.OrdinalIgnoreCase)).Concat (BuildAssemblies)
                 from m in a.Definition?.Modules ?? Enumerable.Empty<ModuleDefinition> ()
                 select new { a, t = m?.GetType (typeFullName) };
             var at = types.FirstOrDefault (x => x.t != null);


### PR DESCRIPTION
This restores the work that @praeclarum did in #144, which were undone when I added the download optimizations. The local caching should still provide a performance improvement. Caching of the zip archive table of contents, while the payload is very small, avoids 3 HTTP round trips required to discover the location of the TOC.

I'm slightly worried about what the behavior will be when the local disk eventually fills up. I think the behavior of the code will be fine, it should revert to pulling over HTTP. The full disk might lead to other issues though.

These bits can be previewed at https://pfluget-test.azurewebsites.net/ which is running in the smallest free Azure service plan. First hit might be slow, as the service will likely need to start up.

