### PR TITLE
Update to .NET 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - name: Set up .NET 5.0
+    - name: Set up .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Build
       run: |

--- a/FuGetGallery.csproj
+++ b/FuGetGallery.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ICSharpCode.Decompiler" Version="3.2.0.3856" />
     <PackageReference Include="Mono.Cecil" Version="0.10.4" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NGraphics" Version="0.6.0-beta1" />
     <PackageReference Include="NuGet.Versioning" Version="5.3.0" />


### PR DESCRIPTION
.NET 5 is [out of support](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core); .NET 6 is LTS.