### PR TITLE
Fix commit url for Azure Devops repos

### DIFF
--- a/Data/PackageData.cs
+++ b/Data/PackageData.cs
@@ -125,7 +125,14 @@ namespace FuGetGallery
         string RepositoryUrlWithoutGit => RepositoryUrl.EndsWith(".git") ?
             RepositoryUrl.Substring(0, RepositoryUrl.Length - 4) :
             RepositoryUrl;
-        string CombinedRepositoryUrlAndCommit => RepositoryUrlWithoutGit + "/tree/" + RepositoryCommit;
+        string CombinedRepositoryUrlAndCommit {
+            get {
+                if (RepositoryUrl.StartsWith ("https://dev.azure.com/"))
+                    return RepositoryUrlWithoutGit + "?version=GC" + RepositoryCommit;
+                else
+                    return RepositoryUrlWithoutGit + "/tree/" + RepositoryCommit;
+            }
+        }
         public string RepositoryUrlTitle => "Source";
 
         public License MatchedLicense { get; set; }


### PR DESCRIPTION
We are managing source code through Azure Devops. This uses another url scheme when browsing commits:
```
https://dev.azure.com/organization/project/_git/repo?version=GBcommit
```
instead of
```
https://github.com/user/project/tree/commit
```
See https://www.nuget.org/packages/Visi.Extensions as example.